### PR TITLE
feat: implement Disciplines/Backgrounds dot-handling

### DIFF
--- a/v20.html
+++ b/v20.html
@@ -712,7 +712,7 @@ V20 Character sheet
 
       <!-- === BACKGROUNDS === -->
 
-      <div>
+      <div id="disciplines-section">
         <h3>disciplines <span>3</span></h3>
         <!-- 
         
@@ -792,7 +792,7 @@ V20 Character sheet
 
       <!-- === BACKGROUNDS === -->
 
-      <div>
+      <div id="backgrounds-section">
         <h3>backgrounds <span>5</span></h3>
         <!-- 
         


### PR DESCRIPTION
## What's in this PR?

This PR adds point allocation functionality to the Disciplines and Backgrounds section.

A new function `initializeSimpleDotLogic` was created, for dot-handling with fixed points (i.e. Disciplines=3, Backgrounds=5, Virtues=7). It should also have the same guards as the Attributes/Abilities dot-handling such as preventing users from going into debt, dynamic point counter, and point allocation only being available once a value is selected in the dropdown.

Similarly, the Disciplines/Backgrounds dot-handling should also reset according to certain conditions.
- If corresponding dropdown (if any point is allocated to it) changes the selected value, then the dots are cleared and relevant points regained.
- If the user has assigned some dots to any Discipline dropdown, and then decide to change their Clan, all allocated dots are cleared and regained.

Dot-handling also works with the non-initial dropdowns.