### PR TITLE
feat: add a 'save as PDF' option after freebie mode

### DIFF
--- a/src/css/app.css
+++ b/src/css/app.css
@@ -217,3 +217,74 @@ main h4 {
 .dot.filled-freebie {
   @apply border-accent bg-accent;
 }
+
+/* ===============================================================
+ # PRINT STYLES
+ ================================================================= 
+ * These styles only apply when the user prints or saves as PDF.
+*/
+@media print {
+
+  /* --- HIDE ALL UNNECESSARY UI ELEMENTS --- */
+  header,                       /* The top header bar */
+  #freebie,                      /* The "Enter Freebie Mode" button */
+  #freebiePointCounter,          /* The entire freebie counter/reset/save bar */
+  [id^="add-"],                 /* All "add new" buttons */
+  .btn-minus {                   /* All "remove" buttons */
+    display: none !important;    /* Force them to be hidden */
+  }
+
+  /* --- PAGE & TEXT STYLING --- */
+  @page {
+    size: A4; /* Or 'letter' */
+    margin: 1.5cm;
+  }
+
+  body {
+    background-color: #ffffff !important; /* Force a white background */
+    color: #000000 !important;          /* Force black text */
+    -webkit-print-color-adjust: exact;  /* Ensure colors print correctly in Chrome/Safari */
+    print-color-adjust: exact;          /* Standard property */
+  }
+  
+  /* Make main headings black */
+  main h2, main h3, main h4 {
+    color: #000000 !important;
+  }
+
+  /* --- LAYOUT ADJUSTMENTS --- */
+  main {
+    padding: 0 !important;
+    margin: 0 !important;
+  }
+  
+  /* Optional: Force sections to not break across pages if possible */
+  section {
+    page-break-inside: avoid;
+  }
+
+  /* --- DOT STYLING FOR PRINT --- */
+  .dot {
+    border-color: #888888 !important; /* Lighter grey border for unfilled dots */
+    background-color: #ffffff !important;
+  }
+
+  .dot.filled {
+    border-color: #000000 !important; /* Solid black border */
+    background-color: #000000 !important; /* Solid black fill */
+  }
+
+  /* Freebie dots can be styled differently if you want, or just black */
+  .dot.filled-freebie {
+    border-color: #333333 !important;
+    background-color: #333333 !important; /* Dark grey for freebie dots */
+  }
+  
+  /* --- FORM ELEMENT STYLING FOR PRINT --- */
+  .textfield, .dropdown, .dropdown-custom, .textfield-custom {
+    background-color: #f0f0f0 !important; /* Light grey background for fields */
+    border: 1px solid #cccccc !important;
+    color: #000000 !important;
+  }
+
+}

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -14,6 +14,7 @@ function initializeFreebieMode() {
   const freebieCounterDisplay = document.getElementById('freebiePointCounter');
   const freebiePointsSpan = freebieCounterDisplay.querySelector('.span');
   const freebieResetButton = document.getElementById('freebiePointReset');
+  const savePdfButton = document.getElementById('save-pdf-btn');
   const body = document.body;
 
   // This is the single "brain" function.
@@ -96,6 +97,7 @@ function initializeFreebieMode() {
     console.log("Freebie Mode Activated.");
     freebieToggleButton.classList.add('hidden');
     freebieCounterDisplay.classList.remove('hidden');
+    savePdfButton.classList.remove('hidden');
     body.classList.add('freebie-mode-active');
     
     initializeFreebieListeners(state, updateAllCalculations);
@@ -112,14 +114,18 @@ function initializeFreebieMode() {
     if (state.isFreebieModeActive) {
       const confirmation = confirm("Are you sure you want to reset all spent freebie points? This cannot be undone.");
       if (confirmation) {
-        // 1. Call our new reset function to clean the DOM.
         resetFreebieState();
-        // 2. Call the master update function to recalculate the state and update the UI.
         updateAllCalculations();
       }
     }
   });
+
+  savePdfButton.addEventListener('click', () => {
+    console.log("Preparing to save as PDF...");
+    window.print();
+  });
 }
+
 function initializeFreebieListeners(state, onUpdateCallback) {
   const costs = { 
     'attributes-section': 5, 'abilities-section': 2, 'disciplines-section': 7, 

--- a/v20.html
+++ b/v20.html
@@ -1050,7 +1050,7 @@ V20 Character sheet
         <img class="w-5 hidden transition group-hover:block"  src="src/reload-white.png" alt="reset freebie points">
       </button>
       <!-- Button to print as PDF -->
-      <button id="save-pdf-btn" class="btn-float group">
+      <button id="save-pdf-btn" class="btn-float group hidden">
         save as <span class="span">PDF</span>
       </button>
     </div>    


### PR DESCRIPTION
# What's in this PR?

Well, the idea was to export the sheet as PDF, but I'm leaving it simply as is. I'll work on an *actual* PDF export in a few. Right now, it just opens the 'Print page as..." dialogue.

Also modifies the floating buttons (the freebie point counter, reset button, and the 'save as PDF' button to align more with the other buttons. Meaning, not fully rounded. Might change this though.)

## `src/css/app.css`
- Create new style class for the floating buttons (`.btn-float`)
- Create whole new print styles for the PDF output
  - Seriously, this will probably guide the light mode feature eh?

## `v20.html`
- Add button for 'Save as PDF' (a lie)
- Modifies the other floating buttons to use the new `.btn-float` style class

## `src/js/app.js`
- Show the 'Save as PDF' button only if the freebie mode is enabled
- Add an event listener to simply, eh, `window.print()`