### PR TITLE
fix: hide header github link and stack freebie buttons on mobile screens

### DIFF
--- a/v20.html
+++ b/v20.html
@@ -1064,15 +1064,17 @@ V20 Character sheet
     </div>
 
     <!-- Freebie point counter & reset button -->
-    <div id="freebiePointCounter" class="hidden flex justify-center items-center gap-3 fixed bottom-16 left-0 right-0">
-      <div id="freebiePointsCounter" class="btn-float group">
-        <p>freebie points left: <span class="span">15</span></p>
+    <div id="freebiePointCounter" class="hidden flex flex-col justify-center items-center gap-3 fixed bottom-16 left-0 right-0 md:flex-row">
+      <div class="flex gap-3">
+        <div id="freebiePointsCounter" class="btn-float group">
+          <p>freebie points left: <span class="span">15</span></p>
+        </div>
+        <!-- Button to reset freebie points. TRIGGER CONFIRM DALOG -->
+        <button id="freebiePointReset" class="btn-float group !p-2.5 !pl-3">
+          <img class="w-5 transition group-hover:hidden" src="/reload-black.png" alt="reset freebie points">
+          <img class="w-5 hidden transition group-hover:block"  src="/reload-white.png" alt="reset freebie points">
+        </button>
       </div>
-      <!-- Button to reset freebie points. TRIGGER CONFIRM DALOG -->
-      <button id="freebiePointReset" class="btn-float group !p-2.5 !pl-3">
-        <img class="w-5 transition group-hover:hidden" src="/reload-black.png" alt="reset freebie points">
-        <img class="w-5 hidden transition group-hover:block"  src="/reload-white.png" alt="reset freebie points">
-      </button>
       <!-- Button to print as PDF -->
       <button id="save-sheet-btn" class="btn-float group hidden">
         <span class="span">save</span> sheet


### PR DESCRIPTION
## Description

This PR addresses some responsiveness issues that were introduced in the previous merges (light mode and freebie modes). Weird UI layouts in the header and freebie buttons should now be fixed. See the screenshots below.

## What's Changed?

- **Fixed header**:
  - The addition of the theme-switcher icon/button caused some weird layout/stacking issue on mobile, such as squishing the Github (*frantan*) link. To address this, the link is now removed on smaller screens, leaving only the theme-swticher button.
- **Fixed Freebie buttons**:
  - Just like with the header, when you enter the freebie mode, the freebie counter, reset, and save sheet buttons are stacked oddly. It's fixed now!
  
## Screenshots

- **Header**:
<img width="421" height="137" alt="image" src="https://github.com/user-attachments/assets/89236af7-6dfd-41fe-84c0-7c315c591c4f" />
<img width="421" height="137" alt="image" src="https://github.com/user-attachments/assets/16d7a2ae-35af-4b5b-b2c6-9b6e4b5c6e89" />


- **Freebie buttons**:
<img width="356" height="123" alt="image" src="https://github.com/user-attachments/assets/5b6b86c2-85dd-4c31-9c7a-321f886f77c7" />
<img width="356" height="123" alt="image" src="https://github.com/user-attachments/assets/37881b86-3788-4a79-912d-e4d4c3d6c34c" />


## About the project's future

This is going to be the very last contribution to the *vanilla* version of this project! From whereonout, **schrecknet-lite** will be using a JS framework (probably React)! This comes due to `custom-dropdowns` being a real pain and this was a long time coming anyhow.

The *vanilla*/*legacy* version will be immortalized on its own branch.