### PR TITLE
fix: fix broken subheading on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,16 +69,16 @@ Homepage
 
       <!-- Tablets Only -->
       <p class="text-textSecondary text-base hidden sm:flex lg:hidden items-center gap-2">
-        welcome to /
+        welcome to
         <span class="flex-1 border-b border-textSecondary"></span>
-        \ by <a href="https://github.com/overuseofrem/schrecknet-lite" class="link">frantan</a>
+        by <a href="https://github.com/overuseofrem/schrecknet-lite" class="link">frantan</a>
       </p>
 
       <!-- Desktop Only -->
       <p class="text-textSecondary text-xl hidden lg:flex items-center gap-2">
-        welcome to /
+        welcome to
         <span class="flex-1 border-b border-textSecondary"></span>
-        \ by <a href="https://github.com/overuseofrem/schrecknet-lite" class="link">frantan</a>
+        by <a href="https://github.com/overuseofrem/schrecknet-lite" class="link">frantan</a>
       </p>
 
     </div>

--- a/index.html
+++ b/index.html
@@ -67,18 +67,18 @@ Homepage
           class="link">frantan</a>
       </p>
 
-      <!--  Tablets Only -->
-      <p class=" text-textSecondary text-base hidden sm:block lg:hidden">
-        welcome to / ------------------------- \ by
-        <a href="https://github.com/overuseofrem/schrecknet-lite"
-          class="link">frantan</a>
+      <!-- Tablets Only -->
+      <p class="text-textSecondary text-base hidden sm:flex lg:hidden items-center gap-2">
+        welcome to /
+        <span class="flex-1 border-b border-textSecondary"></span>
+        \ by <a href="https://github.com/overuseofrem/schrecknet-lite" class="link">frantan</a>
       </p>
 
       <!-- Desktop Only -->
-      <p class=" text-textSecondary text-xl hidden lg:block">
-        welcome to / ---------------------------- \ by
-        <a href="https://github.com/overuseofrem/schrecknet-lite"
-          class="link">frantan</a>
+      <p class="text-textSecondary text-xl hidden lg:flex items-center gap-2">
+        welcome to /
+        <span class="flex-1 border-b border-textSecondary"></span>
+        \ by <a href="https://github.com/overuseofrem/schrecknet-lite" class="link">frantan</a>
       </p>
 
     </div>


### PR DESCRIPTION
The `welcome to / --- \ by frantan"` subheading used hardcoded `-` characters to fake a horizontal rule, which caused the dashes to sit misaligned relative to the text. Replaced with a proper flexbox layout and a `border-b` span that stretches to fill available space and sits flush with the baseline.

## What's changed?

- **`index.html`**
  - Replaced hardcoded `-` dash strings with a `<span class="flex-1 border-b border-textSecondary">` that acts as a proper inline horizontal rule
  - Removed `/` and `\` slash decorations from tablet and desktop subtitle variants
  - Changed `<p>` tags on tablet/desktop variants from `block` to `flex` to support `items-center` alignment

---

> Closes #58 - resolved by replacing literal dash characters with a flexbox border span that aligns correctly at all screen sizes